### PR TITLE
Loc single item call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
-    bootsnap (1.12.0)
+    bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -71,12 +71,12 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.21.0)
+    faker (2.22.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.3.0)
+    faraday (2.4.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (2.0.3)
+    faraday-net_http (2.1.0)
     ffi (1.15.5)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -106,8 +106,6 @@ GEM
     msgpack (1.5.4)
     nio4r (2.5.8)
     nokogiri (1.13.8-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
@@ -231,4 +229,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.3.18
+   2.3.12

--- a/app/controllers/api/v1/location_search_controller.rb
+++ b/app/controllers/api/v1/location_search_controller.rb
@@ -14,9 +14,4 @@ class Api::V1::LocationSearchController < ApplicationController
     def search_params
       params.permit(:location)
     end
-
-    # def self.search_by_street(query)
-    #   query = '%'.concat(query.downcase).concat('%')
-    #   where('lower (street) like ?', query).order(:street)
-    # end
 end

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::ResultsController < ApplicationController
+  def index
+    
+  end
+
+  def show
+
+  end
+end

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ResultsController < ApplicationController
   def index
-    
+    render json: LocFacade.create_all_results(search_params[:location])
   end
 
   def show

--- a/app/facades/loc_result_facade.rb
+++ b/app/facades/loc_result_facade.rb
@@ -5,4 +5,9 @@ class LocResultFacade
       LocIndexResult.new(result)
     end
   end
+
+  def self.create_single_item_result(location, result_index_id, item_id)
+    json = LocService.get_single_location_item_data(location, result_index_id, item_id)
+    LocItemResult.new(json)
+  end
 end

--- a/app/facades/loc_result_facade.rb
+++ b/app/facades/loc_result_facade.rb
@@ -1,0 +1,8 @@
+class LocResultFacade
+  def self.create_loc_index_results(location)
+    json = LocService.get_location_collection_data(location)
+    json[:results].map do |result|
+      LocIndexResult.new(result)
+    end
+  end
+end

--- a/app/poros/loc_index_result.rb
+++ b/app/poros/loc_index_result.rb
@@ -2,11 +2,13 @@ class LocIndexResult
 
   attr_reader :title,
               :collection_link,
-              :id
+              :id,
+              :index_id
 
   def initialize(data)
     @title = data[:title]
     @collection_link = data[:links][:item]
     @id = data[:pk]
+    @index_id = data[:index]
   end
 end

--- a/app/poros/loc_index_result.rb
+++ b/app/poros/loc_index_result.rb
@@ -1,0 +1,12 @@
+class LocIndexResult
+
+  attr_reader :title,
+              :collection_link,
+              :id
+
+  def initialize(data)
+    @title = data[:title]
+    @collection_link = data[:links][:item]
+    @id = data[:pk]
+  end
+end

--- a/app/poros/loc_item_result.rb
+++ b/app/poros/loc_item_result.rb
@@ -1,0 +1,25 @@
+class LocItemResult
+
+  attr_reader :title,
+              :other_titles,
+              :id,
+              :lat,
+              :long,
+              :details,
+              :photo_url,
+              :photo_large,
+              :photo_medium
+
+  def initialize(data)
+    @title = data[:item][:title]
+    @other_titles = data[:item][:other_titles]
+    @id = data[:item][:id]
+    @lat = data[:item][:place][0][:latitude]
+    @long = data[:item][:place][0][:longitude]
+    @details = data[:item][:notes][0][:note]
+
+    @photo_url = data[:resources][0][:url]
+    @photo_medium = data[:resources][0][:medium]
+    @photo_large = data[:resources][0][:large]
+  end
+end

--- a/app/services/loc_service.rb
+++ b/app/services/loc_service.rb
@@ -1,0 +1,20 @@
+class LocService
+  def self.conn
+    Faraday.new('http://www.loc.gov/')
+  end
+
+  def self.get_location_collection_data(location)
+    end_point = 'pictures/search'
+    result = MapquestLocationFacade.get_mapquest_location_data(location)
+    format = (result.county + " " + result.state).downcase
+    # mapquest_result = format.gsub("", " ")
+    # mapquest_result = format_location_for_query(location)
+    response = conn.get(end_point) do |faraday|
+      faraday.params['q'] = format
+      faraday.params['co'] = 'hh'
+      faraday.params['fo'] = 'json'
+    end
+    require "pry"; binding.pry
+    x = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/services/loc_service.rb
+++ b/app/services/loc_service.rb
@@ -15,4 +15,14 @@ class LocService
     end
     JSON.parse(response.body, symbolize_names: true)
   end
+
+  def self.get_single_location_data(location, result_index_id, item_id)
+    all_results = LocResultFacade.create_loc_index_results(location)
+    result = all_results.find { |item| item.index_id == result_index_id }
+    item_id = result.id
+    response = conn.get("pictures/collection/hh/item/#{item_id}/") do |faraday|
+      faraday.params['fo'] = 'json'
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/app/services/loc_service.rb
+++ b/app/services/loc_service.rb
@@ -16,7 +16,7 @@ class LocService
     JSON.parse(response.body, symbolize_names: true)
   end
 
-  def self.get_single_location_data(location, result_index_id, item_id)
+  def self.get_single_location_item_data(location, result_index_id, item_id)
     all_results = LocResultFacade.create_loc_index_results(location)
     result = all_results.find { |item| item.index_id == result_index_id }
     item_id = result.id

--- a/app/services/loc_service.rb
+++ b/app/services/loc_service.rb
@@ -1,20 +1,18 @@
 class LocService
   def self.conn
-    Faraday.new('http://www.loc.gov/')
+    Faraday.new('https://www.loc.gov/')
   end
 
   def self.get_location_collection_data(location)
-    end_point = 'pictures/search'
+    end_point = 'pictures/search/'
     result = MapquestLocationFacade.get_mapquest_location_data(location)
     format = (result.county + " " + result.state).downcase
-    # mapquest_result = format.gsub("", " ")
-    # mapquest_result = format_location_for_query(location)
     response = conn.get(end_point) do |faraday|
       faraday.params['q'] = format
       faraday.params['co'] = 'hh'
       faraday.params['fo'] = 'json'
+      faraday.params['sg'] = 'true'
     end
-    require "pry"; binding.pry
-    x = JSON.parse(response.body, symbolize_names: true)
+    JSON.parse(response.body, symbolize_names: true)
   end
 end

--- a/app/services/mapquest_service.rb
+++ b/app/services/mapquest_service.rb
@@ -4,7 +4,6 @@ class MapquestService
     response = connection.get(end_point) do |faraday|
       faraday.params['key'] = ENV['mapquest_api_key']
       faraday.params['location'] = location
-
     end
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       get '/search', to: 'location_search#show'
 
       get '/results', to: 'results#index'
-      get '/results', to: 'results#show'
+      get '/results/:id', to: 'results#show'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,21 +3,12 @@ Rails.application.routes.draw do
   # get '/'
 
   namespace :api do
-    namespace :v1 do
-      
+    namespace :v1 do      
       resources :users, only: [:index, :show] do
         resources :favorites, only: [:index, :show, :new, :create]
       end
-      # get '/users', to: 'users#index'
       get '/users/register', to: 'users#new'
       post '/users/register', to: 'users#create'
-      # get '/users/:id', to:'users#show'
-      # namespace :users do
-      #   # resources :register, only: [:new, :create], controller: :users
-      # end
-
-      # get '/favorites/new', to: 'favorites#new'
-      # post '/favorites/new', to: 'favorites#create'
 
       get '/search', to: 'location_search#show'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # get '/'
 
   namespace :api do
-    namespace :v1 do      
+    namespace :v1 do
       resources :users, only: [:index, :show] do
         resources :favorites, only: [:index, :show, :new, :create]
       end
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
       post '/users/register', to: 'users#create'
 
       get '/search', to: 'location_search#show'
+
+      get '/results', to: 'results#index'
+      get '/results', to: 'results#show'
     end
   end
 end

--- a/spec/facades/loc_result_facade_spec.rb
+++ b/spec/facades/loc_result_facade_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe LocResultFacade do
   it "gets index results from a location service" do
     results = LocResultFacade.create_loc_index_results('80033')
+    
     expect(results).to be_a Array
     expect(results).to be_all LocIndexResult
+  end
+
+  it "creates a single item object" do
+    result = LocResultFacade.create_single_item_result('80033', 1, 'co0994')
+
+    expect(result).to be_a LocItemResult
   end
 end

--- a/spec/facades/loc_result_facade_spec.rb
+++ b/spec/facades/loc_result_facade_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe LocResultFacade do
+  it "gets index results from a location service" do
+    results = LocResultFacade.create_loc_index_results('80033')
+    expect(results).to be_a Array
+    expect(results).to be_all LocIndexResult
+  end
+end

--- a/spec/poros/loc_index_result_spec.rb
+++ b/spec/poros/loc_index_result_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe LocIndexResult do
+  it "exists and has attributes" do
+    data = {  title: "Result Item 1",
+              links: {:item=>"https://www.loc.gov/pictures/collection/hh/item/co0994/"},
+              pk: "co0994"  }
+    result = LocIndexResult.new(data)
+
+    expect(result).to be_a LocIndexResult
+    expect(result.title).to eq("Result Item 1")
+    expect(result.collection_link).to eq("https://www.loc.gov/pictures/collection/hh/item/co0994/")
+    expect(result.id).to eq("co0994")
+  end
+end

--- a/spec/poros/loc_index_result_spec.rb
+++ b/spec/poros/loc_index_result_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe LocIndexResult do
   it "exists and has attributes" do
     data = {  title: "Result Item 1",
               links: {:item=>"https://www.loc.gov/pictures/collection/hh/item/co0994/"},
-              pk: "co0994"  }
+              pk: "co0994",
+              index: 1  }
     result = LocIndexResult.new(data)
 
     expect(result).to be_a LocIndexResult
     expect(result.title).to eq("Result Item 1")
     expect(result.collection_link).to eq("https://www.loc.gov/pictures/collection/hh/item/co0994/")
     expect(result.id).to eq("co0994")
+    expect(result.index_id).to eq(1)
   end
 end

--- a/spec/poros/loc_item_result_spec.rb
+++ b/spec/poros/loc_item_result_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe LocItemResult do
+  it "exists and has attributes" do
+    data = { item: {  title: "Red Rocks",
+                      other_titles: "Park of Red Rocks",
+                      id: "co0994",
+                      place: [ {  latitude: "39.665578",
+                                  longitude: "-105.206856" } ],
+                      notes: [ {  note: "Park Details" } ] },
+             resources: [ {  url: "photo_path",
+                             large: "large_photo_path",
+                             medium: "medium_photo_path" } ]
+           }
+    item = LocItemResult.new(data)
+
+    expect(item).to be_a LocItemResult
+    expect(item.id).to eq("co0994")
+    expect(item.title).to eq("Red Rocks")
+    expect(item.other_titles).to eq("Park of Red Rocks")
+    expect(item.lat).to eq("39.665578")
+    expect(item.long).to eq("-105.206856")
+    expect(item.details).to eq("Park Details")
+    expect(item.photo_url).to eq("photo_path")
+    expect(item.photo_large).to eq("large_photo_path")
+    expect(item.photo_medium).to eq("medium_photo_path")
+  end
+end

--- a/spec/services/loc_service_spec.rb
+++ b/spec/services/loc_service_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe LocService do
+  it 'establish a base connection' do
+    connection = LocService.conn
+
+    expect(connection.class).to eq(Faraday::Connection)
+  end
+
+  it "returns a collection of results from an endpoint" do
+    results = LocService.get_location_collection_data('80033')
+
+    expect(results).to be_a Hash
+  end
+end

--- a/spec/services/loc_service_spec.rb
+++ b/spec/services/loc_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LocService do
   end
 
   it "returns a single result from an index" do
-    result = LocService.get_single_location_data('80033', 1, 'co0994')
+    result = LocService.get_single_location_item_data('80033', 1, 'co0994')
 
     expect(result).to be_a Hash
     expect(result).to have_key :item

--- a/spec/services/loc_service_spec.rb
+++ b/spec/services/loc_service_spec.rb
@@ -19,4 +19,24 @@ RSpec.describe LocService do
     expect(results[:results][0]).to have_key :links
     expect(results[:results][0][:links]).to have_key :item
   end
+
+  it "returns a single result from an index" do
+    result = LocService.get_single_location_data('80033', 1, 'co0994')
+
+    expect(result).to be_a Hash
+    expect(result).to have_key :item
+    expect(result[:item]).to have_key :title
+    expect(result[:item]).to have_key :other_titles
+    expect(result[:item]).to have_key :id
+    expect(result[:item]).to have_key :place
+    expect(result[:item][:place][0]).to have_key :latitude
+    expect(result[:item][:place][0]).to have_key :longitude
+    expect(result[:item]).to have_key :notes
+    expect(result[:item][:notes][0]).to have_key :note
+
+    expect(result).to have_key :resources
+    expect(result[:resources][0]).to have_key :url
+    expect(result[:resources][0]).to have_key :medium
+    expect(result[:resources][0]).to have_key :large
+  end
 end

--- a/spec/services/loc_service_spec.rb
+++ b/spec/services/loc_service_spec.rb
@@ -11,5 +11,12 @@ RSpec.describe LocService do
     results = LocService.get_location_collection_data('80033')
 
     expect(results).to be_a Hash
+    expect(results).to have_key :results
+    expect(results[:results]).to be_a Array
+
+    expect(results[:results][0]).to have_key :pk
+    expect(results[:results][0]).to have_key :title
+    expect(results[:results][0]).to have_key :links
+    expect(results[:results][0][:links]).to have_key :item
   end
 end


### PR DESCRIPTION
### What does this PR do?
In addition to the previous PR, this includes commits from branch: loc_api_call
LoC Service can now complete calls for both an Index of total results, based upon a MapQuest location search, and a single result item from that index list
Creates new Objects for both the total Index results, and a single Item

Includes attributes of both respective object types that would be required by the frontend to create fully detailed displays

* Routes may need to be updated for the Show path, not sure what it's supposed to look like
* Adds a gem that ended up not being needed, may or may not need to run `bundle install`

### All tests passing?
- [X] Yes
- [ ] No

### SimpleCov 100%?
- [ ] Yes
- [X] No
- If No, what's missing: Something in the UserController, doesn't seem to hit `user_params`
