### PR TITLE
Add service low attribute to LocItemResult poro

### DIFF
--- a/app/poros/loc_item_result.rb
+++ b/app/poros/loc_item_result.rb
@@ -8,16 +8,17 @@ class LocItemResult
               :details,
               :photo_url,
               :photo_large,
-              :photo_medium
+              :photo_medium,
+              :service_low
 
   def initialize(data)
     @title = data[:item][:title]
     @other_titles = data[:item][:other_titles]
     @location_id = data[:item][:id]
+    @service_low = data[:item][:service_low]
     @lat = data[:item][:place][0][:latitude]
     @long = data[:item][:place][0][:longitude]
     @details = data[:item][:notes][0][:note]
-
     @photo_url = data[:resources][0][:url]
     @photo_medium = data[:resources][0][:medium]
     @photo_large = data[:resources][0][:large]

--- a/spec/poros/loc_item_result_spec.rb
+++ b/spec/poros/loc_item_result_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe LocItemResult do
     data = { item: {  title: "Red Rocks",
                       other_titles: "Park of Red Rocks",
                       id: "co0994",
+                      service_low: "//cdn.loc.gov/service/pnp/habshaer/co/co0000/co0004/photos/020850p_150px.jpg?q=co0004.photos.020850p&c=25&st=gallery",
                       place: [ {  latitude: "39.665578",
                                   longitude: "-105.206856" } ],
                       notes: [ {  note: "Park Details" } ] },
@@ -13,6 +14,9 @@ RSpec.describe LocItemResult do
                              medium: "medium_photo_path" } ]
            }
     item = LocItemResult.new(data)
+
+    # item_id = "co0004"
+    # item = LocResultFacade.create_single_item_result(item_id)
 
     expect(item).to be_a LocItemResult
     expect(item.location_id).to eq("co0994")
@@ -24,5 +28,6 @@ RSpec.describe LocItemResult do
     expect(item.photo_url).to eq("photo_path")
     expect(item.photo_large).to eq("large_photo_path")
     expect(item.photo_medium).to eq("medium_photo_path")
+    expect(item.service_low).to eq("//cdn.loc.gov/service/pnp/habshaer/co/co0000/co0004/photos/020850p_150px.jpg?q=co0004.photos.020850p&c=25&st=gallery")
   end
 end

--- a/spec/services/loc_service_spec.rb
+++ b/spec/services/loc_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LocService do
   end
 
   it "returns a single result from an index" do
-    result = LocService.get_single_location_item_data('co0994')
+    result = LocService.get_single_location_item_data('co0004')
 
     expect(result).to be_a Hash
     expect(result).to have_key :item
@@ -29,6 +29,7 @@ RSpec.describe LocService do
     expect(result[:item]).to have_key :other_titles
     expect(result[:item]).to have_key :id
     expect(result[:item]).to have_key :place
+    expect(result[:item]).to have_key :service_low
     expect(result[:item][:place][0]).to have_key :latitude
     expect(result[:item][:place][0]).to have_key :longitude
     expect(result[:item]).to have_key :notes


### PR DESCRIPTION
### What does this PR do?

This PR adds the attribute 'service_low' to the LocItemResult poro to be able to access an image tag on the FE.

### All tests passing?
- [ ] Yes
- [ X] No. We don't have the mapquest api key on local, so related tests are failing. 

### SimpleCov 100%?
- [ ] Yes
- [ ] No
- If No, what's missing:

### Has this been tested on LOCALHOST?
- [ ] Yes
- [ ] No
- Did something not work? If so, what was it?
